### PR TITLE
Use cross-env for environment variables

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -33,7 +33,7 @@
     "core-js": "^2.4.0",
     "eventemitter2": "^1.0.3",
     "isomorphic-fetch": "^2.2.0",
-    "js-utility-belt": "^1.0.5",
+    "js-utility-belt": "^1.1.0",
     "moment": "^2.10.6",
     "q": "^1.4.1",
     "react": "^0.14.8",

--- a/client/package.json
+++ b/client/package.json
@@ -18,10 +18,10 @@
   ],
   "scripts": {
     "lint": "eslint ./",
-    "build": "rimraf ./build && NODE_ENV=extract webpack",
-    "build:dist": "rimraf ./dist && NODE_ENV=production webpack -p",
+    "build": "rimraf ./build && cross-env NODE_ENV=extract webpack",
+    "build:dist": "rimraf ./dist && cross-env NODE_ENV=production webpack -p",
     "clean": "rimraf ./build ./dist",
-    "start": "NODE_ENV=demo node server.demo.js",
+    "start": "cross-env NODE_ENV=demo node server.demo.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "postinstall": "npm run build"
   },
@@ -56,6 +56,7 @@
     "babel-plugin-transform-runtime": "^6.8.0",
     "babel-preset-es2015": "^6.1.2",
     "babel-preset-react": "^6.1.2",
+    "cross-env": "^1.0.8",
     "css-loader": "^0.23.0",
     "dotenv": "^2.0.0",
     "eslint": "^2.10.2",


### PR DESCRIPTION
Use cross-env package to safely set unix-style environment variables on Windows.

Also bumps js-utility-belt to latest to be safe in the future.
