### PR TITLE
Adds iframe windowing to demo server

### DIFF
--- a/client/app_index_template.html
+++ b/client/app_index_template.html
@@ -7,6 +7,17 @@
         <meta charset="UTF-8">
         <title><%= htmlWebpackPlugin.options.title || 'BigchainDB Examples' %></title>
         <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no" />
+
+        <% if (!htmlWebpackPlugin.options.PRODUCTION) { %>
+            <script>
+                if (window.top !== window && !window.top.__REACT_DEVTOOLS_HOLDER__) {
+                    // Pass down the react devtools hook from the parent document to this iframed document
+                    __REACT_DEVTOOLS_GLOBAL_HOOK__ = top.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+                    top.__REACT_DEVTOOLS_HOLDER__ = window;
+                }
+            </script>
+        <% } %>
+
     </head>
     <body>
         <div id="bigchaindb-example-app"></div>

--- a/client/demo/index.html
+++ b/client/demo/index.html
@@ -5,14 +5,13 @@
         <meta charset="UTF-8">
         <title>BigchainDB Examples</title>
         <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no" />
+
+        <link href="./styles.css" rel="stylesheet">
     </head>
     <body>
-        <h1>BigchainDB Examples</h1>
-        <p>You can check these out!</p>
-        <ul>
-            <li><a href="/ontherecord">On the Record</a>
-            <li><a href="/sharetrader">Share Trader</a>
-            <li><a href="/interledger">Interledger</a>
-        </ul>
+        <button id="add-frame-handler" class="button--add-frame">
+            Add window
+        </button>
+        <script src="./windowing.js"></script>
     </body>
 </html>

--- a/client/demo/start.html
+++ b/client/demo/start.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+
+<!-- Start page for selecting example app -->
+
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>BigchainDB Examples</title>
+        <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no" />
+
+        <script>
+            if (window.top !== window) {
+                // Reset the devtools holder so the next time a frame is in one of the examples,
+                // it'll reattach
+                top.__REACT_DEVTOOLS_HOLDER__ = null;
+            }
+        </script>
+
+    </head>
+    <body>
+        <h1>BigchainDB Examples</h1>
+        <p>You can check these out!</p>
+        <ul>
+            <li><a href="/ontherecord">On the Record</a>
+            <li><a href="/sharetrader">Share Trader</a>
+            <li><a href="/interledger">Interledger</a>
+        </ul>
+    </body>
+</html>

--- a/client/demo/styles.css
+++ b/client/demo/styles.css
@@ -9,6 +9,7 @@ body {
     height: 45px;
     position: absolute;
     right: 15px;
+    z-index: 100;
 }
 
 .button--back-frame {

--- a/client/demo/styles.css
+++ b/client/demo/styles.css
@@ -1,0 +1,33 @@
+body {
+    height: 100vh;
+    margin: 0;
+    overflow: hidden;
+}
+
+.button--add-frame {
+    bottom: 15px;
+    height: 45px;
+    position: absolute;
+    right: 15px;
+}
+
+.button--back-frame {
+    height: 25px;
+    position: absolute;
+    left: 10px;
+    top: 10px;
+}
+
+.button--close-frame {
+    height: 25px;
+    position: absolute;
+    right: 10px;
+    top: 10px;
+}
+
+.frame-container {
+    /* Floating frames containers left will allow any frames to be fluidly added or removed */
+    float: left;
+
+    position: relative;
+}

--- a/client/demo/windowing.js
+++ b/client/demo/windowing.js
@@ -1,0 +1,189 @@
+// ESLint doesn't provide a good way of turning of the ES6 features... so we'll have to do it
+// manually.
+/* eslint-disable no-var, prefer-arrow-callback, prefer-template, strict */
+/* global __REACT_DEVTOOLS_GLOBAL_HOOK__ */
+
+'use strict';
+
+(function windowing() {
+    var APP_SOURCE = './start.html';
+    var ADD_FRAME_HANDLER_QUERY = '#add-frame-handler';
+    var IFRAME_QUERY = 'iframe[src="' + APP_SOURCE + '"]';
+    var INITIAL_WINDOWS = 1;
+    var MAX_FRAMES = 4;
+    var ORIG_DOCUMENT_TITLE = document.title;
+
+    var addFrameHandler = document.querySelector(ADD_FRAME_HANDLER_QUERY);
+    var frames = [];
+    var nextFrameNum = 0;
+
+    /** Functions **/
+    function addFrame() {
+        // Create a new iframe, decorate it some handlers for closing, etc, and wrap it in a
+        // container
+        var newFrameContainer = decorateFrameWithCapabilities(createFrame());
+
+        frames.push(newFrameContainer);
+        adjustFrameSizing(frames);
+
+        if (frames.length === MAX_FRAMES) {
+            addFrameHandler.disabled = true;
+        }
+
+        // Finally, push new window into DOM before the button
+        addFrameHandler.parentNode.insertBefore(newFrameContainer, addFrameHandler);
+    }
+
+    // Adjust sizing of each frame based on the total number of frames
+    function adjustFrameSizing(totalFrames) {
+        // Size windows into a 2-column grid
+        var numGridCells = totalFrames.length % 2 ? (totalFrames.length + 1) : totalFrames.length;
+        var baseFrameHeight = 100 / (numGridCells / 2);
+        var baseFrameWidth = 50;
+        var baseFrameHeightPercentage = baseFrameHeight + '%';
+        var baseFrameWidthPercentage = baseFrameWidth + '%';
+
+        totalFrames.forEach(function resizeFrame(frame, ii) {
+            var overflowWidthPercentage;
+
+            if (ii === totalFrames.length - 1 && totalFrames.length % 2) {
+                // When there are an odd number of frames, make the last frame overflow to cover
+                // the leftover bottom area of the screen
+                overflowWidthPercentage = (2 * baseFrameWidth) + '%';
+
+                frame.style.height = baseFrameHeightPercentage;
+                frame.style.width = overflowWidthPercentage;
+            } else {
+                frame.style.height = baseFrameHeightPercentage;
+                frame.style.width = baseFrameWidthPercentage;
+            }
+        });
+    }
+
+    // Creates a new iframe
+    function createFrame() {
+        var frame = document.createElement('iframe');
+        frame.id = getNextFrameId();
+        frame.name = frame.id;
+        frame.src = APP_SOURCE;
+
+        // Frames are always 100% of their containers
+        frame.height = '100%';
+        frame.width = '100%';
+
+        return frame;
+    }
+
+    // Wrap the iframe with a container, add back and close functionality, and attach event listeners
+    function decorateFrameWithCapabilities(frame) {
+        var container = document.createElement('div');
+        var backButton = document.createElement('button');
+        var closeButton = document.createElement('button');
+
+        // Set up container
+        container.className = 'frame-container';
+
+        // Set up backButton
+        backButton.className = 'button--back-frame';
+        backButton.innerHTML = 'Back';
+        backButton.onclick = function goBackInFrame() {
+            frame.contentWindow.history.back();
+        };
+
+        // Set up close button
+        closeButton.className = 'button--close-frame';
+        closeButton.innerHTML = 'Close window ' + frame.name.replace(/example-frame-/, '');
+        closeButton.onclick = function closeFrame() {
+            var removeIndex = frames.indexOf(container);
+            var nextDevtoolFrame;
+
+            if (removeIndex > -1) {
+                frames.splice(removeIndex, 1);
+            }
+
+            // __REACT_DEVTOOLS_HOLDER__ holds the window of the iframe that is attached to the
+            // devtools during development mode. If we are closing that window, attach the devtools
+            // to the next iframe.
+            // eslint-disable-next-line no-underscore-dangle
+            if (window.__REACT_DEVTOOLS_HOLDER__ === frame.contentWindow) {
+                nextDevtoolFrame = frames[0] && frames[0].querySelector(IFRAME_QUERY);
+
+                if (nextDevtoolFrame) {
+                    attachFrameWithReactDevtools(nextDevtoolFrame);
+                } else {
+                    detachCurrentFrameFromReactDevtools();
+                }
+            }
+
+            // Remove the frame from the DOM, adjust remaining frames' sizes, and allow more windows
+            // to be created
+            container.parentNode.removeChild(container);
+
+            adjustFrameSizing(frames);
+            addFrameHandler.disabled = false;
+        };
+
+        // Set up frame listeners
+        frame.onfocus = function frameOnFocus() {
+            document.title = frame.contentDocument.title;
+        };
+        frame.onblur = function frameOnBlur() {
+            document.title = ORIG_DOCUMENT_TITLE;
+        };
+
+        container.appendChild(backButton);
+        container.appendChild(closeButton);
+        container.appendChild(frame);
+
+        return container;
+    }
+
+    // Gets next frame id
+    function getNextFrameId() {
+        return 'example-frame-' + (++nextFrameNum);
+    }
+
+    /**
+     * Devtool utils
+     *
+     * Use __REACT_DEVTOOLS_HOLDER__ to determine which frame the devtool is attached to
+     */
+    // Deregister the current frame from React devtools
+    function detachCurrentFrameFromReactDevtools() {
+        /* eslint-disable no-underscore-dangle */
+        if (window.__REACT_DEVTOOLS_HOLDER__) {
+            window.__REACT_DEVTOOLS_HOLDER__.__REACT_DEVTOOLS_GLOBAL_HOOK__ = null;
+        }
+
+        window.__REACT_DEVTOOLS_HOLDER__ = null;
+        /* eslint-enable no-underscore-dangle */
+    }
+
+    // Register frame with React devtools
+    function attachFrameWithReactDevtools(frame) {
+        /* eslint-disable no-underscore-dangle */
+        // If the frame's hasn't loaded far enough yet to have a window, then we'll give up
+        if (frame.contentWindow) {
+            frame.contentWindow.__REACT_DEVTOOLS_GLOBAL_HOOK__ = __REACT_DEVTOOLS_GLOBAL_HOOK__;
+
+            window.__REACT_DEVTOOLS_HOLDER__ = frame.contentWindow;
+        } else {
+            console.error('Tried to attach React devtools to window: ' + frame.name + ' but ' +
+                          'frame was not loaded yet. React devtools will not be available.');
+        }
+        /* eslint-enable no-underscore-dangle */
+    }
+
+    /** Initialization **/
+    // Initialize initial iframe windows
+    (function initializeWindows(numWindows) {
+        var ii;
+
+        for (ii = 0; ii < numWindows; ++ii) {
+            addFrame();
+        }
+    }(INITIAL_WINDOWS));
+
+    // Attach action listener to addFrameHandler
+    addFrameHandler.onclick = addFrame;
+}());

--- a/client/demo/windowing.js
+++ b/client/demo/windowing.js
@@ -87,7 +87,10 @@
         backButton.className = 'button--back-frame';
         backButton.innerHTML = 'Back';
         backButton.onclick = function goBackInFrame() {
-            frame.contentWindow.history.back();
+            // Only allow the back button to function if we're not on the start page
+            if (frame.contentWindow.location.pathname !== APP_SOURCE.substring(1)) {
+                frame.contentWindow.history.back();
+            }
         };
 
         // Set up close button

--- a/client/demo/windowing.js
+++ b/client/demo/windowing.js
@@ -5,6 +5,14 @@
 
 'use strict';
 
+/**
+ * Windowing script to dynamically create, resize, and destroy iframe instances of the BigchainDB
+ * examples React app. Up to four windows can be open at the same time with one window shown
+ * initially.
+ *
+ * Targets an element with the id `add-frame-handler` to become the button for adding new frames.
+ * All new frames will be appended into the body.
+ */
 (function windowing() {
     var APP_SOURCE = './start.html';
     var ADD_FRAME_HANDLER_QUERY = '#add-frame-handler';

--- a/client/demo/windowing.js
+++ b/client/demo/windowing.js
@@ -58,6 +58,14 @@
                 frame.style.width = baseFrameWidthPercentage;
             }
         });
+
+        // Remove iframe borders if only one frame is visible
+        if (totalFrames.length === 1) {
+            totalFrames[0].querySelector(IFRAME_QUERY).style.borderWidth = 0;
+        } else {
+            // Reset first frame's borders in case they were removed
+            totalFrames[0].querySelector(IFRAME_QUERY).style.borderWidth = '';
+        }
     }
 
     // Creates a new iframe

--- a/client/demo/windowing.js
+++ b/client/demo/windowing.js
@@ -30,8 +30,8 @@
             addFrameHandler.disabled = true;
         }
 
-        // Finally, push new window into DOM before the button
-        addFrameHandler.parentNode.insertBefore(newFrameContainer, addFrameHandler);
+        // Finally, push new window into DOM body
+        document.body.appendChild(newFrameContainer, addFrameHandler);
     }
 
     // Adjust sizing of each frame based on the total number of frames

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -94,6 +94,9 @@ const HTML_PLUGINS = Object.keys(ENTRY).map((entryName) => (
             removeRedundantAttributes: true
         } : false,
         template: path.resolve(__dirname, 'app_index_template.html'),
+
+        // Our own options
+        PRODUCTION: PRODUCTION
     })
 ));
 


### PR DESCRIPTION
![screen shot 2016-06-28 at 6 59 11 pm](https://cloud.githubusercontent.com/assets/4166642/16424950/8459fc02-3d62-11e6-8e1c-6ea2be43dbc0.png)

Enables up to four separate windows to be shown when using the demo server.

Things to note:
- History can be a little bit wonky, mostly when you try to go back on a frame that has no more back history
- React devtool can only be attached to one frame at a time, so debugging might be more difficult when using multiple frames.
- React devtool has a bit of a hard time attaching and reattaching to all of these frames; in particular, it doesn't really know how to clean up after itself so successive reattachments will be a new app in it.
